### PR TITLE
remove wrong function return call at the end of routine

### DIFF
--- a/asm_spi/Src/asm_spi_write_var.s
+++ b/asm_spi/Src/asm_spi_write_var.s
@@ -60,5 +60,5 @@ bit_delay22:
 	  LDR R3, =#(SCS_HIGH | CLK_LOW )
 	  STR R3, [R2, #o_GPIO_BSRR]		// write SCK low and data on SDA
       POP  {R5, R6 }
-	  BX LR                            // Return from function
+	//  BX LR                            // Return from function
 


### PR DESCRIPTION
This function return is not matched by a function call, error from original function. now is used as inline code only